### PR TITLE
Add option for applying extra css classes to printed documents

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ export default class PrintPlugin extends Plugin {
 
             if (typeof fileExtraClasses === "string") {
                 customClasses = [fileExtraClasses];
-            } else {
+            } else if (typeof fileExtraClasses === "object") {
                 customClasses = Object.values(fileExtraClasses)
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,13 +86,28 @@ export default class PrintPlugin extends Plugin {
             return;
         }
 
+        let customClasses: string[] = [];
+        if (this.settings.extraClasses) {
+            const fileExtraClasses: string | object = this.app
+                .metadataCache
+                .getFileCache(file)
+                ?.frontmatter
+                ?.cssClasses
+
+            if (typeof fileExtraClasses === "string") {
+                customClasses = [fileExtraClasses];
+            } else {
+                customClasses = Object.values(fileExtraClasses)
+            }
+        }
+
         const content = await generatePreviewContent(file, this.settings.printTitle, this.app);
         if (!content) {
             return;
         }
 
         const cssString = await generatePrintStyles(this.app, this.manifest, this.settings);
-        await openPrintModal(content, this.settings, cssString);
+        await openPrintModal(content, this.settings, cssString, customClasses);
     }
 
     async printSelection() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,6 +84,16 @@ export class PrintSettingTab extends PluginSettingTab {
                 }));
 
         new Setting(containerEl)
+            .setName('Extra Classes')
+            .setDesc('When using @media print, any `customCssClasses` in the frontmatter will also get added to the document. This helps if you have multiple formats you want to be able to print into (Only works for printing notes, not folders or selections).')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.debugMode)
+                .onChange(async (value) => {
+                    this.plugin.settings.debugMode = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        new Setting(containerEl)
             .setName('Custom CSS')
             .setDesc(`You can add a custom "print.css" to "Appearance > CSS snippets", then this toggle will be enabled and synced with CSS snippets. The easier way is to add your styles using @media print {body {...}}.`)
             .addToggle(toggle => toggle

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -87,9 +87,9 @@ export class PrintSettingTab extends PluginSettingTab {
             .setName('Extra Classes')
             .setDesc('When using @media print, any `customCssClasses` in the frontmatter will also get added to the document. This helps if you have multiple formats you want to be able to print into (Only works for printing notes, not folders or selections).')
             .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.debugMode)
+                .setValue(this.plugin.settings.extraClasses)
                 .onChange(async (value) => {
-                    this.plugin.settings.debugMode = value;
+                    this.plugin.settings.extraClasses = value;
                     await this.plugin.saveSettings();
                 }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface PrintPluginSettings {
     hrPageBreaks: boolean;
     debugMode: boolean;
     usePreview: boolean;
+    extraClasses: boolean;
 }
 
 export const DEFAULT_SETTINGS: PrintPluginSettings = {
@@ -25,5 +26,6 @@ export const DEFAULT_SETTINGS: PrintPluginSettings = {
     combineFolderNotes: false,
     hrPageBreaks: false,
     debugMode: false,
-    usePreview: true
+    usePreview: true,
+    extraClasses: false,
 };

--- a/src/utils/printModal.ts
+++ b/src/utils/printModal.ts
@@ -9,7 +9,7 @@ import { Printd } from 'printd'
  * @param cssString 
  * @returns 
  */
-export async function openPrintModal(content: HTMLElement, settings: PrintPluginSettings, cssString: string): Promise<void> {
+export async function openPrintModal(content: HTMLElement, settings: PrintPluginSettings, cssString: string, extraClasses?: string[]): Promise<void> {
     const htmlElement = document.createElement('html');
     const headElement = document.createElement('head');
 
@@ -27,6 +27,8 @@ export async function openPrintModal(content: HTMLElement, settings: PrintPlugin
 
     const bodyElement = document.createElement('body');
     bodyElement.className = 'obsidian-print';
+    if (extraClasses) bodyElement.classList.add(...extraClasses)
+
     bodyElement.appendChild(content);
 
     htmlElement.appendChild(bodyElement);


### PR DESCRIPTION
Hi, thank you for the awesome plugin! Been getting alot of use out of it in the short time since I found it.

There is one thing I was struggling with, which is that I can only really print in a single format, so I thought it might be useful to add the option to add the classes from the `cssClasses` in the documents frontmatter. I attached a before and after example just to show it working, along with the snippet I used for it:

```css
@media print {
  /* Other fancifying styles ... */
  
  body.test {
    color: red;
  }
}
```
[test_before.pdf](https://github.com/user-attachments/files/19927214/test_before.pdf)
[test_after.pdf](https://github.com/user-attachments/files/19927213/test_after.pdf)

Currently only printed single notes are supported by this (not folder or selection). It should be possible to handle the other two cases. But I wanted to start small to see what you think about the idea then expand it later :sweat_smile: 