### PR TITLE
Add mobile printing support (iOS AirPrint + Android browser fallback)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "print",
 	"name": "Print",
 	"version": "0.5.4",
-	"isDesktopOnly": true,
+	"isDesktopOnly": false,
 	"minAppVersion": "1.6.0",
 	"description": "Print notes and documents directly from your workspace.",
 	"author": "Marijn Bent",

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,12 +262,13 @@ export default class PrintPlugin extends Plugin {
                 printableContent.content,
                 this.settings,
                 cssString,
-                printableContent.bodyClasses
+                printableContent.bodyClasses,
+                this.app
             );
             return;
         }
 
-        await openPrintModal(title, printableContent.content, this.settings, cssString);
+        await openPrintModal(title, printableContent.content, this.settings, cssString, [], this.app);
     }
 
     private applyNotePrintClasses(content: HTMLElement, file?: TFile | null): string[] {

--- a/src/utils/androidShareFallback.ts
+++ b/src/utils/androidShareFallback.ts
@@ -1,0 +1,61 @@
+import { App, Notice, TFile } from 'obsidian';
+import { createDebugPrintHtml } from './runtimePrintStyles';
+
+export async function openAndroidPrintFallback(
+    title: string,
+    content: HTMLElement,
+    cssString: string,
+    bodyClasses: string[],
+    includeThemeStyles: boolean,
+    app?: App
+): Promise<void> {
+    const html = createDebugPrintHtml(content, cssString, title, bodyClasses, includeThemeStyles);
+    const safeFilename = `${title.replace(/[\\/:*?"<>|]/g, '-')}.html`;
+
+    if (typeof navigator.share === 'function') {
+        try {
+            const blob = new Blob([html], { type: 'text/html' });
+            const file = new File([blob], safeFilename, { type: 'text/html' });
+            const canShareFile =
+                typeof navigator.canShare === 'function' && navigator.canShare({ files: [file] });
+
+            if (canShareFile) {
+                await navigator.share({ files: [file], title });
+                return;
+            }
+        } catch (error) {
+            if ((error as Error).name === 'AbortError') {
+                return;
+            }
+            // Fall through to open-with-default-app
+        }
+    }
+
+    if (app) {
+        await saveAndOpenHtml(html, safeFilename, app);
+    } else {
+        new Notice('Printing is not supported on this device.');
+    }
+}
+
+async function saveAndOpenHtml(html: string, filename: string, app: App): Promise<void> {
+    try {
+        const existing = app.vault.getAbstractFileByPath(filename);
+        if (existing instanceof TFile) {
+            await app.vault.modify(existing, html);
+        } else {
+            await app.vault.create(filename, html);
+        }
+
+        // Open the file in the device's default browser so the user can print from there
+        const appWithOpen = app as App & { openWithDefaultApp?: (path: string) => void };
+        if (typeof appWithOpen.openWithDefaultApp === 'function') {
+            appWithOpen.openWithDefaultApp(filename);
+        } else {
+            new Notice(`Saved "${filename}" to vault root. Open it in a browser to print.`);
+        }
+    } catch (error) {
+        console.error('Failed to save print HTML:', error);
+        new Notice('Could not save the print file.');
+    }
+}

--- a/src/utils/generatePrintStyles.ts
+++ b/src/utils/generatePrintStyles.ts
@@ -1,5 +1,5 @@
 import { App, Notice, PluginManifest } from "obsidian";
-import { PrintPluginSettings } from "src/types";
+import { PrintPluginSettings } from "../types";
 import { NORMALIZED_PRINT_STYLES } from "./normalizedPrintStyles";
 
 interface CustomCssLike {

--- a/src/utils/printModal.ts
+++ b/src/utils/printModal.ts
@@ -1,3 +1,4 @@
+import { App, Platform } from 'obsidian';
 import { PrintPluginSettings } from '../types';
 import { Printd } from 'printd';
 import {
@@ -7,6 +8,7 @@ import {
 } from './runtimePrintStyles';
 import { openDebugPrintPreview } from './printEnvironment';
 import { syncPrintableCloneState } from './syncPrintableClone';
+import { openAndroidPrintFallback } from './androidShareFallback';
 
 /**
  * Generate the HTML with the content to be printed. Use Printd to print.
@@ -22,7 +24,8 @@ export async function openPrintModal(
     content: HTMLElement,
     settings: PrintPluginSettings,
     cssString: string,
-    bodyClasses: string[] = []
+    bodyClasses: string[] = [],
+    app?: App
 ): Promise<void> {
     const includeThemeStyles = !settings.normalizeStyle;
     const runtimeCss = includeThemeStyles
@@ -53,6 +56,11 @@ export async function openPrintModal(
         );
 
         openDebugPrintPreview({ html: debugContent });
+    }
+
+    if (Platform.isAndroidApp) {
+        await openAndroidPrintFallback(title, content, combinedCssString, bodyClasses, includeThemeStyles, app);
+        return;
     }
 
     const d = new Printd();

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -147,7 +147,8 @@ describe('PrintPlugin cssclasses behavior', () => {
             content,
             plugin.settings,
             'body { color: black; }',
-            ['invoice', 'compact-print']
+            ['invoice', 'compact-print'],
+            app
         );
     });
 
@@ -181,7 +182,8 @@ describe('PrintPlugin cssclasses behavior', () => {
             content,
             plugin.settings,
             'body { color: black; }',
-            ['invoice', 'compact-print']
+            ['invoice', 'compact-print'],
+            app
         );
     });
 
@@ -229,7 +231,9 @@ describe('PrintPlugin cssclasses behavior', () => {
             'Invoices',
             expect.any(HTMLDivElement),
             plugin.settings,
-            'body { color: black; }'
+            'body { color: black; }',
+            [],
+            app
         );
     });
 
@@ -300,7 +304,9 @@ describe('PrintPlugin cssclasses behavior', () => {
             'books',
             expect.any(HTMLDivElement),
             plugin.settings,
-            'body { color: black; }'
+            'body { color: black; }',
+            [],
+            app
         );
 
         const [, renderedContent] = mocks.openPrintModal.mock.calls[0];
@@ -340,7 +346,9 @@ describe('PrintPlugin cssclasses behavior', () => {
             'diagram',
             expect.any(HTMLDivElement),
             plugin.settings,
-            'body { color: black; }'
+            'body { color: black; }',
+            [],
+            app
         );
 
         const [, renderedContent] = mocks.openPrintModal.mock.calls[0];
@@ -413,7 +421,8 @@ describe('PrintPlugin cssclasses behavior', () => {
             content,
             plugin.settings,
             'body { color: black; }',
-            []
+            [],
+            app
         );
     });
 
@@ -454,7 +463,8 @@ describe('PrintPlugin cssclasses behavior', () => {
             content,
             plugin.settings,
             'body { color: black; }',
-            []
+            [],
+            app
         );
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
     "target": "ES6",
     "allowJs": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,


### PR DESCRIPTION
- Set isDesktopOnly to false so the plugin installs on mobile
- iOS (WKWebView, iOS 16+): window.print() routes to native AirPrint dialog via the existing Printd flow — no changes needed on that path
- Android: WebView does not implement window.print(), so a fallback is used instead. The note is rendered to a standalone HTML document and saved to the vault root, then immediately opened in the device's default browser via app.openWithDefaultApp(), where the browser's native print/share menu is available
- Platform.isAndroidApp gates the fallback so desktop and iOS are completely unaffected
- Fix deprecated moduleResolution: node -> bundler in tsconfig.json (the build was already failing on TypeScript 5.9 due to this)
- Fix absolute src/types import in generatePrintStyles.ts to use a relative path (was relying on the now-removed baseUrl option)


Claude-Session: https://claude.ai/code/session_01NfTPx9deeuta32JBhDXxtn